### PR TITLE
Changing variable representation $SKEW

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/gcp/libvirt/cert-rotation/conf/openshift-e2e-gcp-libvirt-cert-rotation-conf-commands.sh
+++ b/ci-operator/step-registry/openshift/e2e/gcp/libvirt/cert-rotation/conf/openshift-e2e-gcp-libvirt-cert-rotation-conf-commands.sh
@@ -429,7 +429,7 @@ run-on "${control_nodes} ${compute_nodes}" "systemctl disable chronyd --now"
 run-on "${control_nodes} ${compute_nodes}" "
 timedatectl status
 timedatectl set-ntp false
-timedatectl set-time '${SKEW}'
+timedatectl set-time ${SKEW}
 timedatectl status
 "
 run-on "${control_nodes} ${compute_nodes}" "sleep 10 && systemctl start kubelet"


### PR DESCRIPTION
- Faced below error while following `time-skew-test.sh` commands.  Removing quotes.

~~~
# timedatectl set-time '${SKEW}'
Failed to parse time specification '${SKEW}': Invalid argument
~~~